### PR TITLE
readable & read

### DIFF
--- a/gledki.go
+++ b/gledki.go
@@ -185,7 +185,7 @@ func (t *Gledki) loadCompiled(fullPath string) (string, error) {
 	}
 	// t.Logger.Debugf("loadCompiled('%s')", fullPath)
 	fullPath = fullPath + CompiledSuffix
-	if fileIsReadable(fullPath) {
+	if isReadable(fullPath) {
 		data, _ := os.ReadFile(fullPath)
 		t.compiled[fullPath] = string(data)
 		return t.compiled[fullPath], nil
@@ -264,7 +264,7 @@ func (t *Gledki) LoadFile(path string) (string, error) {
 	if text, ok := t.files[path]; ok && len(text) > 0 {
 		return text, nil
 	}
-	if fileIsReadable(path) {
+	if isReadable(path) {
 		data, _ := os.ReadFile(path)
 		t.files[path] = string(data)
 		return t.files[path], nil
@@ -295,7 +295,7 @@ func (t *Gledki) toFullPath(path string) string {
 		if !strings.HasPrefix(path, root) {
 			foundPath = filepath.Join(root, path)
 		}
-		if fileIsReadable(foundPath) {
+		if isReadable(foundPath) {
 			return foundPath
 		} else {
 			continue
@@ -353,15 +353,13 @@ func dirExists(path string) bool {
 	return true
 }
 
-func fileIsReadable(path string) bool {
-	finfo, err := os.Stat(path)
-	if err != nil && errors.Is(err, os.ErrNotExist) {
+func isReadable(path string) bool {
+	fh, err := os.Open(path)
+	if err != nil {
 		return false
 	}
-	if finfo.Mode().IsRegular() && finfo.Mode().Perm()&0400 == 0400 {
-		return true
-	}
-	return false
+	_ = fh.Close()
+	return true
 }
 
 func findBinDir() string {

--- a/gledki.go
+++ b/gledki.go
@@ -184,13 +184,12 @@ func (t *Gledki) loadCompiled(fullPath string) (string, error) {
 		return text, nil
 	}
 	// t.Logger.Debugf("loadCompiled('%s')", fullPath)
-	fullPath = fullPath + CompiledSuffix
-	if isReadable(fullPath) {
-		data, _ := os.ReadFile(fullPath)
-		t.compiled[fullPath] = string(data)
-		return t.compiled[fullPath], nil
+	data, err := os.ReadFile(fullPath + CompiledSuffix)
+	if err != nil {
+		return "", fmt.Errorf("compiled file: %v", err)
 	}
-	return "", errors.New(spf("File '%s' could not be read!", fullPath))
+	t.compiled[fullPath] = string(data)
+	return t.compiled[fullPath], nil
 }
 
 func (t *Gledki) storeCompiled(fullPath, text string) {
@@ -264,12 +263,12 @@ func (t *Gledki) LoadFile(path string) (string, error) {
 	if text, ok := t.files[path]; ok && len(text) > 0 {
 		return text, nil
 	}
-	if isReadable(path) {
-		data, _ := os.ReadFile(path)
-		t.files[path] = string(data)
-		return t.files[path], nil
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
 	}
-	return "", fmt.Errorf(`file '%s' could not be read!`, path)
+	t.files[path] = string(data)
+	return t.files[path], nil
 }
 
 /*

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kberov/gledki
 go 1.23.1
 
 require (
-	github.com/labstack/gommon v0.4.1
+	github.com/labstack/gommon v0.4.2
 	github.com/valyala/fasttemplate v1.2.2
 )
 
@@ -11,5 +11,5 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	golang.org/x/sys v0.14.0 // indirect
+	golang.org/x/sys v0.25.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kberov/gledki
 
-go 1.21.4
+go 1.23.1
 
 require (
 	github.com/labstack/gommon v0.4.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/labstack/gommon v0.4.1 h1:gqEff0p/hTENGMABzezPoPSRtIh1Cvw0ueMOe0/dfOk=
-github.com/labstack/gommon v0.4.1/go.mod h1:TyTrpPqxR5KMk8LKVtLmfMjeQ5FEkBYdxLYPw/WfrOM=
+github.com/labstack/gommon v0.4.2 h1:F8qTUNXgG1+6WQmqoUWnz8WiEU60mXVVw0P4ht1WRA0=
+github.com/labstack/gommon v0.4.2/go.mod h1:QlUFxVM+SNXhDL/Z7YhocGIBYOiwB0mXm1+1bAPHPyU=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -17,7 +17,7 @@ github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQ
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
-golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
+golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
There is no point in testing the readability of a file and then ignoring the error from the actual read operation. Other reasons might exist, why we can't read a file, beside the r-bit.

We should try to read it (e.g. using `os.ReadFile`) and, if required, check the error, if, this e.g. is `os.ErrNotExist`. But in the two cases I found, we really need to read the file.